### PR TITLE
feat(backend): implement queue worker for async job matching (SUB-3)

### DIFF
--- a/backend/service/jobs/jobMatch.service.ts
+++ b/backend/service/jobs/jobMatch.service.ts
@@ -92,9 +92,9 @@ export async function deleteJobMatch(userId: number, jobId: string) {
 }
 
 /**
- * Persist multiple match results to database
+ * Persist multiple match results to database atomically
  * Upserts each match by composite key (userId + jobId)
- * Includes confidence score in new updates
+ * Wraps in transaction so batch is all-or-nothing
  */
 export async function persistMatchResults(
   userId: number,
@@ -106,31 +106,32 @@ export async function persistMatchResults(
   }>
 ) {
   try {
-    const promises = results.map((result) =>
-      prisma.job_match.upsert({
-        where: {
-          userId_jobId: {
+    // Wrap all upserts in a single transaction for atomicity
+    return await prisma.$transaction(
+      results.map((result) =>
+        prisma.job_match.upsert({
+          where: {
+            userId_jobId: {
+              userId,
+              jobId: result.jobId,
+            },
+          },
+          create: {
             userId,
             jobId: result.jobId,
+            score: result.score,
+            confidence: result.confidence,
+            reason: result.reason,
           },
-        },
-        create: {
-          userId,
-          jobId: result.jobId,
-          score: result.score,
-          confidence: result.confidence,
-          reason: result.reason,
-        },
-        update: {
-          score: result.score,
-          confidence: result.confidence,
-          reason: result.reason,
-          updatedAt: new Date(),
-        },
-      })
+          update: {
+            score: result.score,
+            confidence: result.confidence,
+            reason: result.reason,
+            updatedAt: new Date(),
+          },
+        })
+      )
     );
-
-    return await Promise.all(promises);
   } catch (error) {
     console.error("Persist match results error:", error);
     throw new Error("Failed to persist match results");

--- a/backend/service/jobs/matchQueue.ts
+++ b/backend/service/jobs/matchQueue.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from "crypto";
 import type { MatchResult, NormalizedJob } from "../types/parsing.js";
+import type { ParsedResume } from "../../validators/resume.schema.js";
 import { logger } from "../../lib/logger.js";
+import prisma from "../../lib/prisma.js";
+import * as llmMatcherV2 from "./llmJobMatcherV2.js";
+import * as regexMatcher from "./regexJobMatcher.js";
+import * as jobMatchService from "./jobMatch.service.js";
+import * as cache from "./matchCache.js";
 
 /**
  * Queue item for async job matching
@@ -104,7 +110,7 @@ class MatchQueue {
 
   /**
    * Process queue items (background worker)
-   * This would be called periodically or triggered by events
+   * Fetches resume, runs LLM + regex fallback, persists results
    */
   async processQueue(): Promise<void> {
     if (this.processing) return;
@@ -114,24 +120,75 @@ class MatchQueue {
     try {
       for (const [queueId, item] of this.queue.entries()) {
         if (item.status === "queued") {
-          item.status = "processing";
+          try {
+            item.status = "processing";
 
-          logger.info("MATCH_PROCESSING", {
-            queueId,
-            userId: item.userId,
-            jobCount: item.jobs.length,
-          });
+            logger.info("MATCH_PROCESSING", {
+              queueId,
+              userId: item.userId,
+              jobCount: item.jobs.length,
+            });
 
-          // Here, we would call the actual matching logic
-          // For now, this is a placeholder
-          // In real implementation, this would call matchJobsWithLLM / regex
-          // and then call setResults or setError
+            // Fetch user's resume
+            const user = await prisma.user.findUnique({
+              where: { id: item.userId },
+            });
 
-          // Simulate async work
-          await new Promise((resolve) => setTimeout(resolve, 100));
+            if (!user?.clerkId) {
+              throw new Error("User not found or missing clerkId");
+            }
 
-          // This is where results would be set:
-          // this.setResults(queueId, results);
+            const resume = await prisma.resume.findFirst({
+              where: { userId: user.clerkId },
+            });
+
+            if (!resume?.parsedData) {
+              throw new Error("Resume not found or not yet parsed");
+            }
+
+            // Step 1: Run LLM matcher (v2)
+            const llmResults = await llmMatcherV2.matchJobsWithLLMV2(
+              resume.parsedData as ParsedResume,
+              item.jobs,
+              item.userId
+            );
+
+            // Step 2: Merge with regex fallback for missing jobs
+            const finalResults = await mergeWithConditionalRegexFallback(
+              llmResults,
+              resume.parsedData as ParsedResume,
+              item.jobs,
+              item.userId
+            );
+
+            // Step 3: Persist to database
+            await jobMatchService.persistMatchResults(item.userId, finalResults);
+
+            // Step 4: Cache results
+            for (const result of finalResults) {
+              cache.setInCache(item.userId, result.jobId, result);
+            }
+
+            // Step 5: Mark as completed
+            this.setResults(queueId, finalResults);
+
+            logger.info("QUEUE_ITEM_PROCESSED", {
+              queueId,
+              userId: item.userId,
+              resultsCount: finalResults.length,
+            });
+          } catch (error) {
+            const errorMsg =
+              error instanceof Error ? error.message : String(error);
+
+            logger.error("QUEUE_ITEM_PROCESSING_FAILED", {
+              queueId,
+              userId: item.userId,
+              error: errorMsg,
+            });
+
+            this.setError(queueId, errorMsg);
+          }
         }
       }
     } catch (error) {
@@ -193,6 +250,46 @@ class MatchQueue {
 
 // Singleton instance
 const matchQueue = new MatchQueue();
+
+// ===== Helper: Merge LLM + Regex Fallback =====
+/**
+ * Compare LLM and Regex results, fallback for missing jobs
+ */
+async function mergeWithConditionalRegexFallback(
+  llmResults: MatchResult[],
+  resume: ParsedResume,
+  jobs: NormalizedJob[],
+  userId: number
+): Promise<MatchResult[]> {
+  const llmByJob = new Map<string, MatchResult>(
+    llmResults
+      .filter((r) => Number.isFinite(r.score) && Number.isFinite(r.confidence))
+      .map((result) => [result.jobId, { ...result, source: "llm" }])
+  );
+
+  const missingJobs = jobs.filter((job) => !llmByJob.has(job.job_id));
+  if (missingJobs.length === 0) {
+    return Array.from(llmByJob.values()).sort((a, b) => b.score - a.score);
+  }
+
+  logger.warn("LLM_RESULTS_INCOMPLETE_USING_REGEX_FALLBACK_QUEUE", {
+    userId,
+    llmCount: llmByJob.size,
+    totalJobs: jobs.length,
+    fallbackJobs: missingJobs.length,
+  });
+
+  const regexResults = regexMatcher.matchJobsWithRegex(resume, missingJobs);
+
+  for (const regexResult of regexResults) {
+    llmByJob.set(regexResult.jobId, {
+      ...regexResult,
+      source: "regex",
+    });
+  }
+
+  return Array.from(llmByJob.values()).sort((a, b) => b.score - a.score);
+}
 
 // Periodic cleanup (every 30 minutes)
 setInterval(() => {

--- a/backend/service/jobs/matchQueue.ts
+++ b/backend/service/jobs/matchQueue.ts
@@ -8,9 +8,36 @@ import * as regexMatcher from "./regexJobMatcher.js";
 import * as jobMatchService from "./jobMatch.service.js";
 import * as cache from "./matchCache.js";
 
+// ===== Error Sanitization =====
 /**
- * Queue item for async job matching
+ * Sanitize internal error messages for client exposure
+ * Hides Prisma/LLM/stack details, returns generic safe message or specific known error
  */
+function sanitizeErrorMessage(rawError: string): string {
+  // Map known internal errors to safe client messages
+  if (
+    rawError.includes("PrismaClientKnownRequestError") ||
+    rawError.includes("Prisma") ||
+    rawError.includes("SQL")
+  ) {
+    return "Database error occurred during processing";
+  }
+  if (rawError.includes("LLM_TIMEOUT") || rawError.includes("timed out")) {
+    return "Processing took too long, please try again";
+  }
+  if (rawError.includes("API") || rawError.includes("api")) {
+    return "External service temporarily unavailable";
+  }
+  if (rawError.includes("timeout")) {
+    return "Processing timeout exceeded";
+  }
+  // Generic fallback for unknown errors
+  if (rawError.length > 100 || rawError.includes("at ") || rawError.includes("stack")) {
+    return "An internal error occurred during processing";
+  }
+  // Safe messages can pass through (e.g., "User not found or missing clerkId" is already generic)
+  return rawError;
+}
 interface QueueItem {
   queueId: string;
   userId: number;
@@ -92,17 +119,22 @@ class MatchQueue {
 
   /**
    * Mark queue item as failed
+   * Logs full error internally but stores sanitized message for client
    */
-  setError(queueId: string, error: string): void {
+  setError(queueId: string, error: string, internalDetails?: Record<string, unknown>): void {
     const item = this.queue.get(queueId);
     if (item) {
       item.status = "failed";
-      item.error = error;
+      // Sanitize error message before storing (client-facing)
+      item.error = sanitizeErrorMessage(error);
       item.completedAt = new Date();
 
+      // Log full error details internally for debugging
       logger.error("MATCH_FAILED", {
         queueId,
-        error,
+        sanitizedError: item.error,
+        rawError: error,
+        ...internalDetails,
         duration: item.completedAt.getTime() - item.createdAt.getTime(),
       });
     }
@@ -161,15 +193,37 @@ class MatchQueue {
               item.userId
             );
 
-            // Step 3: Persist to database
+            // Step 3: Validate complete coverage before persisting
+            const requestedJobIds = new Set(item.jobs.map((j) => j.job_id));
+            const matchedJobIds = new Set(finalResults.map((r) => r.jobId));
+            const missingJobs = Array.from(requestedJobIds).filter(
+              (jobId) => !matchedJobIds.has(jobId)
+            );
+
+            if (missingJobs.length > 0) {
+              const errorMsg = `Incomplete match results: ${missingJobs.length} of ${item.jobs.length} jobs unmatched`;
+              logger.warn("QUEUE_INCOMPLETE_RESULTS", {
+                queueId,
+                userId: item.userId,
+                requestedCount: item.jobs.length,
+                matchedCount: finalResults.length,
+                missingCount: missingJobs.length,
+              });
+              this.setError(queueId, "Processing could not complete for all jobs", {
+                missingJobCount: missingJobs.length,
+              });
+              continue;
+            }
+
+            // Step 4: Persist to database
             await jobMatchService.persistMatchResults(item.userId, finalResults);
 
-            // Step 4: Cache results
+            // Step 5: Cache results
             for (const result of finalResults) {
               cache.setInCache(item.userId, result.jobId, result);
             }
 
-            // Step 5: Mark as completed
+            // Step 6: Mark as completed
             this.setResults(queueId, finalResults);
 
             logger.info("QUEUE_ITEM_PROCESSED", {
@@ -185,9 +239,12 @@ class MatchQueue {
               queueId,
               userId: item.userId,
               error: errorMsg,
+              errorType: error instanceof Error ? error.constructor.name : typeof error,
             });
 
-            this.setError(queueId, errorMsg);
+            this.setError(queueId, errorMsg, {
+              errorType: error instanceof Error ? error.constructor.name : typeof error,
+            });
           }
         }
       }

--- a/backend/service/jobs/matchQueue.ts
+++ b/backend/service/jobs/matchQueue.ts
@@ -311,6 +311,7 @@ const matchQueue = new MatchQueue();
 // ===== Helper: Merge LLM + Regex Fallback =====
 /**
  * Compare LLM and Regex results, fallback for missing jobs
+ * Filters LLM results to only include requested job IDs (prevents hallucinated jobIds)
  */
 async function mergeWithConditionalRegexFallback(
   llmResults: MatchResult[],
@@ -318,9 +319,18 @@ async function mergeWithConditionalRegexFallback(
   jobs: NormalizedJob[],
   userId: number
 ): Promise<MatchResult[]> {
+  // Build set of requested job IDs for validation
+  const requestedJobIds = new Set(jobs.map((j) => j.job_id));
+
+  // Filter LLM results: valid scores AND requested job IDs only (prevent hallucinated IDs)
   const llmByJob = new Map<string, MatchResult>(
     llmResults
-      .filter((r) => Number.isFinite(r.score) && Number.isFinite(r.confidence))
+      .filter(
+        (r) =>
+          Number.isFinite(r.score) &&
+          Number.isFinite(r.confidence) &&
+          requestedJobIds.has(r.jobId) // Only include if jobId was in the request
+      )
       .map((result) => [result.jobId, { ...result, source: "llm" }])
   );
 


### PR DESCRIPTION
#127 
Wire matchQueue.processQueue() to execute real matching logic:
- Fetch user resume from DB
- Call matchJobsWithLLMV2() for primary matching
- Fallback to regexJobMatcher for gaps
- Persist results to database
- Cache results in memory
- Update queue status on completion or error

This enables POST /jobs/match/batch to enqueue jobs and GET /jobs/match/batch/:queueId to poll results.

Fixes: CVPilot MVP SUB-3
Previous: 100ms placeholder sleep with no actual processing
Updated: Full integration with LLM+regex matching pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real AI-powered job matching in the queue with conditional fallback to improve coverage; results are persisted and cached for faster access.

* **Bug Fixes**
  * Per-item failure handling so other queue items continue processing; improved logging and sanitized client-facing error messages.
  * Added completeness validation that flags and records incomplete matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->